### PR TITLE
Fix email validation regex

### DIFF
--- a/ZenCoderDemo/Account/Register.aspx
+++ b/ZenCoderDemo/Account/Register.aspx
@@ -23,7 +23,7 @@
             <div class="col-md-10">
                 <asp:TextBox runat="server" ID="Email" CssClass="form-control" />
                 <asp:RequiredFieldValidator runat="server" ControlToValidate="Email" CssClass="text-danger" ErrorMessage="The email field is required." />
-                <asp:RegularExpressionValidator runat="server" ControlToValidate="Email" CssClass="text-danger" ValidationExpression="^\S+@\S+\.\S+$" ErrorMessage="A valid email is required." />
+                <asp:RegularExpressionValidator runat="server" ControlToValidate="Email" CssClass="text-danger" ValidationExpression="^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$" ErrorMessage="A valid email is required." />
             </div>
         </div>
         <div class="form-group">

--- a/ZenCoderDemo/Account/Register.aspx.cs
+++ b/ZenCoderDemo/Account/Register.aspx.cs
@@ -1,6 +1,7 @@
-﻿using Microsoft.AspNet.Identity;
+using Microsoft.AspNet.Identity;
 using System;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Web.UI;
 using ZenCoderDemo;
 
@@ -8,6 +9,12 @@ public partial class Account_Register : Page
 {
     protected void CreateUser_Click(object sender, EventArgs e)
     {
+        if (!Regex.IsMatch(Email.Text, @"^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$"))
+        {
+            ErrorMessage.Text = "A valid email is required.";
+            return;
+        }
+
         var manager = new UserManager();
         var user = new ApplicationUser() { UserName = UserName.Text, Email = Email.Text };
         IdentityResult result = manager.Create(user, Password.Text);


### PR DESCRIPTION
## Summary
- tighten email regex on registration form
- add server-side validation using regex

## Testing
- `dotnet test` *(fails: command not found)*