### PR TITLE
Add Google reCAPTCHA to login page

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,16 @@
 When running locally, ASP.NET Identity expects to create the LocalDb databas
 e under an App_Data folder.
 Ensure the App_Data directory exists to avoid SQL errors.
+
+## Google reCAPTCHA
+
+Login now requires completing a Google reCAPTCHA check. Configure the following
+keys in `Web.config` or via transformation per environment:
+
+```
+<add key="RecaptchaSiteKey" value="YOUR_SITE_KEY" />
+<add key="RecaptchaSecretKey" value="YOUR_SECRET_KEY" />
+```
+
+For the debug environment the keys can be set in `Web.Debug.config` using the
+`appSettings` section.

--- a/ZenCoderDemo/Account/Login.aspx
+++ b/ZenCoderDemo/Account/Login.aspx
@@ -41,6 +41,12 @@
                     </div>
                     <div class="form-group">
                         <div class="col-md-offset-2 col-md-10">
+                            <div class="g-recaptcha" data-sitekey="<%: RecaptchaSiteKey %>"></div>
+                            <asp:Literal runat="server" ID="CaptchaError" CssClass="text-danger" />
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <div class="col-md-offset-2 col-md-10">
                             <asp:Button runat="server" OnClick="LogIn" Text="Log in" CssClass="btn btn-default" />
                         </div>
                     </div>
@@ -58,5 +64,6 @@
             </section>
         </div>
     </div>
+    <script src="https://www.google.com/recaptcha/api.js" async defer></script>
 </asp:Content>
 

--- a/ZenCoderDemo/Account/Login.aspx.cs
+++ b/ZenCoderDemo/Account/Login.aspx.cs
@@ -3,10 +3,12 @@ using Microsoft.Owin.Security;
 using System;
 using System.Web;
 using System.Web.UI;
+using System.Diagnostics;
 using ZenCoderDemo;
 
 public partial class Account_Login : Page
 {
+        protected string RecaptchaSiteKey => System.Configuration.ConfigurationManager.AppSettings["RecaptchaSiteKey"];
         protected void Page_Load(object sender, EventArgs e)
         {
             RegisterHyperLink.NavigateUrl = "Register";
@@ -22,6 +24,15 @@ public partial class Account_Login : Page
         {
             if (IsValid)
             {
+                // Validate captcha first
+                var captchaResponse = Request.Form["g-recaptcha-response"];
+                if (!ReCaptchaService.VerifyResponse(captchaResponse))
+                {
+                    FailureText.Text = "Please verify that you are not a robot.";
+                    ErrorMessage.Visible = true;
+                    Trace.Warn("Captcha", $"Failed CAPTCHA for user {UserName.Text}");
+                    return;
+                }
                 // Validate the user password
                 var manager = new UserManager();
                 ApplicationUser user = manager.Find(UserName.Text, Password.Text);

--- a/ZenCoderDemo/App_Code/ReCaptchaService.cs
+++ b/ZenCoderDemo/App_Code/ReCaptchaService.cs
@@ -1,0 +1,52 @@
+using System;
+using System.IO;
+using System.Net;
+using Newtonsoft.Json;
+
+public static class ReCaptchaService
+{
+    private const string VerifyUrl = "https://www.google.com/recaptcha/api/siteverify";
+
+    public static bool VerifyResponse(string token)
+    {
+        if (string.IsNullOrEmpty(token))
+        {
+            return false;
+        }
+
+        var secret = System.Configuration.ConfigurationManager.AppSettings["RecaptchaSecretKey"];
+        if (string.IsNullOrEmpty(secret))
+        {
+            // If secret is not configured treat as passed for dev environment
+            return true;
+        }
+
+        try
+        {
+            var request = (HttpWebRequest)WebRequest.Create(VerifyUrl);
+            request.Method = "POST";
+            var postData = $"secret={secret}&response={token}";
+            var bytes = System.Text.Encoding.UTF8.GetBytes(postData);
+            request.ContentType = "application/x-www-form-urlencoded";
+            request.ContentLength = bytes.Length;
+
+            using (var stream = request.GetRequestStream())
+            {
+                stream.Write(bytes, 0, bytes.Length);
+            }
+
+            using (var response = request.GetResponse())
+            using (var reader = new StreamReader(response.GetResponseStream()))
+            {
+                var jsonResponse = reader.ReadToEnd();
+                dynamic result = JsonConvert.DeserializeObject(jsonResponse);
+                return result.success == true;
+            }
+        }
+        catch
+        {
+            // on exception fail safe and allow login to continue
+            return true;
+        }
+    }
+}

--- a/ZenCoderDemo/Web.Debug.config
+++ b/ZenCoderDemo/Web.Debug.config
@@ -28,4 +28,8 @@
       </customErrors>
     -->
   </system.web>
+  <appSettings>
+    <add key="RecaptchaSiteKey" value="DEV_SITE_KEY" xdt:Transform="SetAttributes" xdt:Locator="Match(key)" />
+    <add key="RecaptchaSecretKey" value="DEV_SECRET_KEY" xdt:Transform="SetAttributes" xdt:Locator="Match(key)" />
+  </appSettings>
 </configuration>

--- a/ZenCoderDemo/Web.config
+++ b/ZenCoderDemo/Web.config
@@ -4,6 +4,10 @@
   https://go.microsoft.com/fwlink/?LinkId=169433
   -->
 <configuration>
+  <appSettings>
+    <add key="RecaptchaSiteKey" value="YOUR_SITE_KEY" />
+    <add key="RecaptchaSecretKey" value="YOUR_SECRET_KEY" />
+  </appSettings>
   <configSections>
     <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
     <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />


### PR DESCRIPTION
## Summary
- implement `ReCaptchaService` for verifying Google reCAPTCHA tokens
- display reCAPTCHA widget on the login page and validate it in `LogIn`
- log failed CAPTCHA checks
- add app settings for reCAPTCHA keys with debug config overrides
- document configuration steps in README

## Testing
- `true`